### PR TITLE
Update SharedPtr with better member methods

### DIFF
--- a/lib/libtoolchain/source/filesystem/LocalFileSystem.cpp
+++ b/lib/libtoolchain/source/filesystem/LocalFileSystem.cpp
@@ -95,23 +95,23 @@ void tc::filesystem::LocalFileSystem::getCurrentDirectory(tc::filesystem::Path& 
 	tc::SharedPtr<char16_t> raw_char16_path = new char16_t[MAX_PATH];
 
 	// get current directory
-	if (GetCurrentDirectoryW(MAX_PATH, (LPWSTR)(*raw_char16_path)) == false)
+	if (GetCurrentDirectoryW(MAX_PATH, (LPWSTR)(raw_char16_path.get())) == false)
 	{
 		throw tc::Exception(kClassName, "Failed to get current directory (" + std::to_string(GetLastError()) + ")");
 	}
 
-	path = Path(*raw_char16_path);
+	path = Path(raw_char16_path.get());
 #else
 	setCurrentDirectory(Path("."));
 
 	tc::SharedPtr<char> raw_current_working_directory = new char[PATH_MAX];
 
-	if (getcwd(*raw_current_working_directory, PATH_MAX) == nullptr)
+	if (getcwd(raw_current_working_directory.get(), PATH_MAX) == nullptr)
 	{
 		throw tc::Exception(kClassName, "Failed to get current working directory (getcwd)" + std::string(strerror(errno)) + ")");
 	}
 
-	path = Path(*raw_current_working_directory);
+	path = Path(raw_current_working_directory.get());
 #endif
 }
 

--- a/lib/libtoolchain/source/filesystem/SandboxFile.cpp
+++ b/lib/libtoolchain/source/filesystem/SandboxFile.cpp
@@ -28,10 +28,10 @@ uint64_t tc::filesystem::SandboxFile::pos()
 void tc::filesystem::SandboxFile::read(byte_t* out, size_t len)
 {
 	// assert proper position in file
-	(*mFile)->seek(mVirtualOffset + mFileBaseOffset);
+	mFile->seek(mVirtualOffset + mFileBaseOffset);
 
 	// read data
-	(*mFile)->read(out, len);
+	mFile->read(out, len);
 
 	// update virtual offset
 	seek(mVirtualOffset + len);
@@ -40,10 +40,10 @@ void tc::filesystem::SandboxFile::read(byte_t* out, size_t len)
 void tc::filesystem::SandboxFile::write(const byte_t* out, size_t len)
 {
 	// assert proper position in file
-	(*mFile)->seek(mVirtualOffset + mFileBaseOffset);
+	mFile->seek(mVirtualOffset + mFileBaseOffset);
 
 	// write data
-	(*mFile)->write(out, len);
+	mFile->write(out, len);
 
 	// update virtual offset
 	seek(mVirtualOffset + len);

--- a/lib/libtoolchain/source/filesystem/SandboxFileSystem.cpp
+++ b/lib/libtoolchain/source/filesystem/SandboxFileSystem.cpp
@@ -7,8 +7,8 @@ tc::filesystem::SandboxFileSystem::SandboxFileSystem(const tc::SharedPtr<tc::fil
 	mCurrentDirectory("/")
 {
 	// get full path of root
-	(*mFileSystem)->setCurrentDirectory(root_path);
-	(*mFileSystem)->getCurrentDirectory(mRootPath);
+	mFileSystem->setCurrentDirectory(root_path);
+	mFileSystem->getCurrentDirectory(mRootPath);
 }
 
 tc::filesystem::IFile* tc::filesystem::SandboxFileSystem::openFile(const tc::filesystem::Path& path, FileAccessMode mode)
@@ -18,7 +18,7 @@ tc::filesystem::IFile* tc::filesystem::SandboxFileSystem::openFile(const tc::fil
 	sandboxPathToRealPath(path, real_path);
 
 	// open file
-	return (*mFileSystem)->openFile(real_path, mode);
+	return mFileSystem->openFile(real_path, mode);
 }
 
 void tc::filesystem::SandboxFileSystem::deleteFile(const tc::filesystem::Path& path)
@@ -28,7 +28,7 @@ void tc::filesystem::SandboxFileSystem::deleteFile(const tc::filesystem::Path& p
 	sandboxPathToRealPath(path, real_path);
 
 	// delete file
-	(*mFileSystem)->deleteFile(real_path);
+	mFileSystem->deleteFile(real_path);
 }
 
 void tc::filesystem::SandboxFileSystem::getCurrentDirectory(tc::filesystem::Path& path)
@@ -43,7 +43,7 @@ void tc::filesystem::SandboxFileSystem::setCurrentDirectory(const tc::filesystem
 	sandboxPathToRealPath(path, real_path);
 
 	// set current directory
-	(*mFileSystem)->setCurrentDirectory(real_path);
+	mFileSystem->setCurrentDirectory(real_path);
 
 	// save current directory
 	realPathToSandboxPath(real_path, mCurrentDirectory);
@@ -56,7 +56,7 @@ void tc::filesystem::SandboxFileSystem::createDirectory(const tc::filesystem::Pa
 	sandboxPathToRealPath(path, real_path);
 
 	// create directory
-	(*mFileSystem)->createDirectory(real_path);
+	mFileSystem->createDirectory(real_path);
 }
 
 void tc::filesystem::SandboxFileSystem::removeDirectory(const tc::filesystem::Path& path)
@@ -66,7 +66,7 @@ void tc::filesystem::SandboxFileSystem::removeDirectory(const tc::filesystem::Pa
 	sandboxPathToRealPath(path, real_path);
 
 	// remove directory
-	(*mFileSystem)->removeDirectory(real_path);
+	mFileSystem->removeDirectory(real_path);
 }
 
 void tc::filesystem::SandboxFileSystem::getDirectoryInfo(const tc::filesystem::Path& path, DirectoryInfo& info)
@@ -77,7 +77,7 @@ void tc::filesystem::SandboxFileSystem::getDirectoryInfo(const tc::filesystem::P
 
 	// get real directory info
 	tc::filesystem::DirectoryInfo real_info;
-	(*mFileSystem)->getDirectoryInfo(real_path, real_info);
+	mFileSystem->getDirectoryInfo(real_path, real_info);
 
 	// convert directory absolute path
 	tc::filesystem::Path sandbox_dir_path;

--- a/tests/LocalFileSystem-test/source/main.cpp
+++ b/tests/LocalFileSystem-test/source/main.cpp
@@ -20,15 +20,15 @@ void testFileCreate()
 	{
 		tc::SharedPtr<tc::filesystem::IFile> file = fs.openFile(kAsciiFilePath, tc::filesystem::FAM_CREATE);
 
-		if ((*file)->size() != 0)
+		if (file->size() != 0)
 		{
 			throw tc::Exception("main.cpp", "file opened in create mode does not have a size of 0");
 		}
 
-		(*file)->write((const byte_t*)kRandomString.c_str(), kRandomString.length());
+		file->write((const byte_t*)kRandomString.c_str(), kRandomString.length());
 
 		
-		if ((*file)->size() != kRandomString.length())
+		if (file->size() != kRandomString.length())
 		{
 			throw tc::Exception("main.cpp", "after writing data, file size is not correct");
 		}
@@ -50,15 +50,15 @@ void testFileRead()
 	{
 		tc::SharedPtr<tc::filesystem::IFile> file = fs.openFile(kAsciiFilePath, tc::filesystem::FAM_READ);
 
-		if ((*file)->size() != kRandomString.length())
+		if (file->size() != kRandomString.length())
 		{
 			throw tc::Exception("main.cpp", "Unexpected file size");
 		}
 
 		tc::SharedPtr<byte_t> check = new byte_t[kRandomString.length()];
-		(*file)->read(*check, kRandomString.length());
+		file->read(check.get(), kRandomString.length());
 
-		if (memcmp(*check, kRandomString.c_str(), kRandomString.size()) != 0)
+		if (memcmp(check.get(), kRandomString.c_str(), kRandomString.size()) != 0)
 		{
 			throw tc::Exception("main.cpp", "Data in file was not correct");
 		}
@@ -79,32 +79,32 @@ void testFileEdit()
 	{
 		tc::SharedPtr<tc::filesystem::IFile> file = fs.openFile(kAsciiFilePath, tc::filesystem::FAM_EDIT);
 
-		if ((*file)->size() != kRandomString.length())
+		if (file->size() != kRandomString.length())
 		{
 			throw tc::Exception("main.cpp", "Unexpected file size");
 		}
 
-		(*file)->seek(kRandomString.length());
-		(*file)->write((const byte_t*)kRandomString.c_str(), kRandomString.length());
+		file->seek(kRandomString.length());
+		file->write((const byte_t*)kRandomString.c_str(), kRandomString.length());
 
-		(*file)->seek(7);
-		(*file)->write((const byte_t*)kTestPhrase.c_str(), kTestPhrase.length());
+		file->seek(7);
+		file->write((const byte_t*)kTestPhrase.c_str(), kTestPhrase.length());
 
 		tc::SharedPtr<byte_t> check = new byte_t[kRandomString.length()*2];
-		(*file)->seek(0);
-		(*file)->read(*check, kRandomString.length()*2);
+		file->seek(0);
+		file->read(check.get(), kRandomString.length()*2);
 
-		if (memcmp(*check + kRandomString.length(), kRandomString.c_str(), kRandomString.size()) != 0)
+		if (memcmp(check.get() + kRandomString.length(), kRandomString.c_str(), kRandomString.size()) != 0)
 		{
 			throw tc::Exception("main.cpp", "Data(kRandomStr[1][:]) in file was not correct");
 		}
 
-		if (memcmp(*check + 7, kTestPhrase.c_str(), kTestPhrase.size()) != 0)
+		if (memcmp(check.get() + 7, kTestPhrase.c_str(), kTestPhrase.size()) != 0)
 		{
 			throw tc::Exception("main.cpp", "Data(kTestPhrase[:]) in file was not correct");
 		}
 
-		if (memcmp(*check, kRandomString.c_str(), 7) != 0)
+		if (memcmp(check.get(), kRandomString.c_str(), 7) != 0)
 		{
 			throw tc::Exception("main.cpp", "Data(kRandomStr[0][0:7]) in file was not correct");
 		}
@@ -125,12 +125,12 @@ void testUnicodePath()
 	{
 		tc::SharedPtr<tc::filesystem::IFile> file = fs.openFile(kUtf8TestPath, tc::filesystem::FAM_CREATE);
 
-		if ((*file)->size() != 0)
+		if (file->size() != 0)
 		{
 			throw tc::Exception("main.cpp", "file opened in create mode does not have a size of 0\n");
 		}
 
-		(*file)->write((const byte_t*)kRandomString.c_str(), kRandomString.length());
+		file->write((const byte_t*)kRandomString.c_str(), kRandomString.length());
 
 
 		std::cout << "[LocalFileSystem-test] testUnicodePath() : PASS" << std::endl;
@@ -181,7 +181,7 @@ void testTryWriteInReadOnlyMode()
 	{
 		tc::SharedPtr<tc::filesystem::IFile> file = fs.openFile(kAsciiFilePath, tc::filesystem::FAM_READ);
 
-		(*file)->write((const byte_t*)kRandomString.c_str(), kRandomString.length());
+		file->write((const byte_t*)kRandomString.c_str(), kRandomString.length());
 
 		std::cout << "[LocalFileSystem-test] testTryWriteInReadOnlyMode() : FAIL (Did not throw exception when write() was called)" << std::endl;
 	}
@@ -201,7 +201,7 @@ void testTryReadBeyondFileSize()
 
 		tc::SharedPtr<byte_t> buffer = new byte_t[0x10000];
 
-		(*file)->read(*buffer, 0x10000);
+		file->read(buffer.get(), 0x10000);
 
 		std::cout << "[LocalFileSystem-test] testTryReadBeyondFileSize() : FAIL (Did not throw exception when read() attemped to read beyond file size)" << std::endl;
 	}

--- a/tests/SandboxFile-test/source/main.cpp
+++ b/tests/SandboxFile-test/source/main.cpp
@@ -65,7 +65,7 @@ void testSize()
 			// get sandbox filesystem
 			tc::SharedPtr<tc::filesystem::IFile> sb_file = new tc::filesystem::SandboxFile(file, sandbox_offset, sandbox_size);
 
-			if ((*sb_file)->size() != sandbox_size)
+			if (sb_file->size() != sandbox_size)
 			{
 				throw tc::Exception("main.cpp", "Unexpected file size");
 			}
@@ -114,16 +114,16 @@ void testSeekPos()
 			tc::SharedPtr<tc::filesystem::IFile> sb_file = new tc::filesystem::SandboxFile(file, sandbox_offset, sandbox_size);
 
 			uint64_t offset_to_seek = 0x337;
-			(*sb_file)->seek(offset_to_seek);
+			sb_file->seek(offset_to_seek);
 
-			if ((*sb_file)->pos() != offset_to_seek)
+			if (sb_file->pos() != offset_to_seek)
 			{
 				throw tc::Exception("main.cpp", "Was not able to seek as expected");
 			}
 
-			(*sb_file)->read(nullptr, 0x20);
+			sb_file->read(nullptr, 0x20);
 
-			if ((*sb_file)->pos() != offset_to_seek + 0x20)
+			if (sb_file->pos() != offset_to_seek + 0x20)
 			{
 				throw tc::Exception("main.cpp", "Was not able to seek as expected");
 			}
@@ -178,12 +178,12 @@ void testRead()
 			tc::SharedPtr<tc::filesystem::IFile> sb_file = new tc::filesystem::SandboxFile(file, sandbox_offset, sandbox_size);
 
 			uint64_t offset_to_seek = 0x337;
-			(*sb_file)->seek(offset_to_seek);
+			sb_file->seek(offset_to_seek);
 
 			byte_t* dummy_ptr = (byte_t*)0xcafe;
 			size_t dummy_read_len = 0xdeadbabe;
 
-			(*sb_file)->read(dummy_ptr, dummy_read_len);
+			sb_file->read(dummy_ptr, dummy_read_len);
 
 			std::cout << "[SandboxFile-test] testRead() : PASS" << std::endl;
 		}
@@ -233,12 +233,12 @@ void testWrite()
 			tc::SharedPtr<tc::filesystem::IFile> sb_file = new tc::filesystem::SandboxFile(file, sandbox_offset, sandbox_size);
 
 			uint64_t offset_to_seek = 0x337;
-			(*sb_file)->seek(offset_to_seek);
+			sb_file->seek(offset_to_seek);
 
 			byte_t* dummy_ptr = (byte_t*)0xcafe;
 			size_t dummy_read_len = 0xdeadbabe;
 
-			(*sb_file)->write(dummy_ptr, dummy_read_len);
+			sb_file->write(dummy_ptr, dummy_read_len);
 
 			std::cout << "[SandboxFile-test] testWrite() : PASS" << std::endl;
 		}

--- a/tests/SandboxFileSystem-test/source/main.cpp
+++ b/tests/SandboxFileSystem-test/source/main.cpp
@@ -77,8 +77,8 @@ void testSandboxRootPath()
 
 			// save sandbox real path
 			tc::filesystem::Path sandbox_real_root;
-			(*sb_fs)->setCurrentDirectory(tc::filesystem::Path("/"));
-			(*fs)->getCurrentDirectory(sandbox_real_root);
+			sb_fs->setCurrentDirectory(tc::filesystem::Path("/"));
+			fs->getCurrentDirectory(sandbox_real_root);
 
 			// check the sandbox is generating the correct path
 			if (sandbox_real_root != dummyfs_curdir + sandbox_relative_root)
@@ -141,7 +141,7 @@ void testCreateFile()
 			tc::SharedPtr<tc::filesystem::IFileSystem> sb_fs = new tc::filesystem::SandboxFileSystem(fs, dummyfs_curdir + testdir_path);
 
 			// attempt to create file
-			(*sb_fs)->openFile(tc::filesystem::Path("/a_dir/testfile"), tc::filesystem::FAM_CREATE);
+			sb_fs->openFile(tc::filesystem::Path("/a_dir/testfile"), tc::filesystem::FAM_CREATE);
 			
 			std::cout << "[SandboxFileSystem-test] testCreateFile() : PASS" << std::endl;
 		}
@@ -196,7 +196,7 @@ void testOpenFile()
 			tc::SharedPtr<tc::filesystem::IFileSystem> sb_fs = new tc::filesystem::SandboxFileSystem(fs, dummyfs_curdir + testdir_path);
 
 			// attempt to open file
-			(*sb_fs)->openFile(tc::filesystem::Path("/a_dir/testfile"), tc::filesystem::FAM_READ);
+			sb_fs->openFile(tc::filesystem::Path("/a_dir/testfile"), tc::filesystem::FAM_READ);
 			
 			std::cout << "[SandboxFileSystem-test] testOpenFile() : PASS" << std::endl;
 		}
@@ -246,7 +246,7 @@ void testRemoveFile()
 			tc::SharedPtr<tc::filesystem::IFileSystem> sb_fs = new tc::filesystem::SandboxFileSystem(fs, dummyfs_curdir + testdir_path);
 
 			// attempt to delete file
-			(*sb_fs)->deleteFile(tc::filesystem::Path("/a_dir/testfile"));
+			sb_fs->deleteFile(tc::filesystem::Path("/a_dir/testfile"));
 
 			std::cout << "[SandboxFileSystem-test] testRemoveFile() : PASS" << std::endl;
 		}
@@ -297,7 +297,7 @@ void testCreateDirectory()
 			tc::SharedPtr<tc::filesystem::IFileSystem> sb_fs = new tc::filesystem::SandboxFileSystem(fs, dummyfs_curdir + testdir_path);
 
 			// attempt to create directory
-			(*sb_fs)->createDirectory(tc::filesystem::Path("/a_dir/testdir/hey"));
+			sb_fs->createDirectory(tc::filesystem::Path("/a_dir/testdir/hey"));
 
 			std::cout << "[SandboxFileSystem-test] testCreateDirectory() : PASS" << std::endl;
 		}
@@ -347,7 +347,7 @@ void testRemoveDirectory()
 			tc::SharedPtr<tc::filesystem::IFileSystem> sb_fs = new tc::filesystem::SandboxFileSystem(fs, dummyfs_curdir + testdir_path);
 
 			// attempt to remove directory
-			(*sb_fs)->removeDirectory(tc::filesystem::Path("/a_dir/testdir/hey"));
+			sb_fs->removeDirectory(tc::filesystem::Path("/a_dir/testdir/hey"));
 
 			std::cout << "[SandboxFileSystem-test] testRemoveDirectory() : PASS" << std::endl;
 		}
@@ -402,11 +402,11 @@ void testGetDirectoryListing()
 
 			// save sandbox dir info
 			tc::filesystem::DirectoryInfo sb_dir_info;
-			(*sb_fs)->getDirectoryInfo(tc::filesystem::Path("/a_dir/testdir/hey"), sb_dir_info);
+			sb_fs->getDirectoryInfo(tc::filesystem::Path("/a_dir/testdir/hey"), sb_dir_info);
 
 			// save real dir info
 			tc::filesystem::DirectoryInfo real_dir_info;
-			(*fs)->getDirectoryInfo(dummyfs_curdir + tc::filesystem::Path("testdir/a_dir/testdir/hey"), real_dir_info);
+			fs->getDirectoryInfo(dummyfs_curdir + tc::filesystem::Path("testdir/a_dir/testdir/hey"), real_dir_info);
 
 			if (sb_dir_info.getChildFileList() != real_dir_info.getChildFileList())
 			{
@@ -494,14 +494,14 @@ void testNavigateUpSandboxEscape()
 
 			// get info about current directory
 			tc::filesystem::DirectoryInfo dir_info;
-			(*sb_fs)->getDirectoryInfo(tc::filesystem::Path("./../../../../../../../../../../../../../..///./././"), dir_info);
+			sb_fs->getDirectoryInfo(tc::filesystem::Path("./../../../../../../../../../../../../../..///./././"), dir_info);
 			
 			if (dir_info.getDirectoryPath() != tc::filesystem::Path("/"))
 			{
 				throw tc::Exception("main.cpp", "Sandbox directory path not as expected");
 			}
 
-			if (((DummyFileSystem*)(*fs))->getLastUsedPath() != dummyfs_curdir + sandbox_relative_root)
+			if (((DummyFileSystem*)fs.operator->())->getLastUsedPath() != dummyfs_curdir + sandbox_relative_root)
 			{
 				throw tc::Exception("main.cpp", "Real directory path not as expected");
 			}
@@ -565,8 +565,8 @@ void testOpenFileOutsideSandbox()
 			tc::SharedPtr<tc::filesystem::IFileSystem> sb_fs = new tc::filesystem::SandboxFileSystem(fs, dummyfs_curdir + sandbox_relative_root);
 			  
 			// try to open the file just outside the sandbox
-			(*sb_fs)->setCurrentDirectory(tc::filesystem::Path("/"));
-			tc::SharedPtr<tc::filesystem::IFile> inacessible_file = (*sb_fs)->openFile(tc::filesystem::Path("../inaccessible_file0"), tc::filesystem::FAM_READ);
+			sb_fs->setCurrentDirectory(tc::filesystem::Path("/"));
+			tc::SharedPtr<tc::filesystem::IFile> inacessible_file = sb_fs->openFile(tc::filesystem::Path("../inaccessible_file0"), tc::filesystem::FAM_READ);
 
 			std::cout << "[SandboxFileSystem-test] testOpenFileOutsideSandbox() : PASS" << std::endl;
 		}

--- a/tests/SharedPtr-test/source/main.cpp
+++ b/tests/SharedPtr-test/source/main.cpp
@@ -2,111 +2,829 @@
 #include <iostream>
 #include <tc/SharedPtr.h>
 
-static const uint32_t kStartValue = 0xCAFEBABE;
-static const uint32_t kExpectedValue = 0xDEADBEEF;
-
-class TestClass
+void testDefaultConstructor()
 {
-public:
-	TestClass(uint32_t& var):
-		mVar(var),
-		mOnDeathVal(kExpectedValue)
-	{}
-
-	~TestClass()
+	std::cout << "[SharedPtr-test] testDefaultConstructor : ";
+	try
 	{
-		mVar = mOnDeathVal;
-	}
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo;
+		}
 
-	void setOnDeathVal(uint32_t val)
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
 	{
-		mOnDeathVal = val;
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
 	}
-private:
-	uint32_t& mVar;	
-	uint32_t mOnDeathVal;
-};
+}
 
-void outOfScope1(uint32_t& var)
+void testPrimPtrConstructor()
 {
-	tc::SharedPtr<TestClass> obj = new TestClass(var);
+	std::cout << "[SharedPtr-test] testPrimPtrConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(new int);
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testPrimPtrAssignmentOperator()
+{
+	std::cout << "[SharedPtr-test] testPrimPtrAssignmentOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo = new int;
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testPrimPtrCopyConstructor()
+{
+	std::cout << "[SharedPtr-test] testPrimPtrCopyConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(new int);
+			tc::SharedPtr<int> bar(foo);
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testPrimPtrCopyOperator()
+{
+	std::cout << "[SharedPtr-test] testPrimPtrCopyOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(new int);
+			tc::SharedPtr<int> bar = foo;
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testStructPtrConstructor()
+{
+	std::cout << "[SharedPtr-test] testStructPtrConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			tc::SharedPtr<sFooStruct> foo(new sFooStruct);
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testStructPtrAssignmentOperator()
+{
+	std::cout << "[SharedPtr-test] testStructPtrAssignmentOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			tc::SharedPtr<sFooStruct> foo = new sFooStruct;
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testStructPtrCopyConstructor()
+{
+	std::cout << "[SharedPtr-test] testStructPtrCopyConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			tc::SharedPtr<sFooStruct> foo(new sFooStruct);
+			tc::SharedPtr<sFooStruct> bar(foo);
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testStructPtrCopyOperator()
+{
+	std::cout << "[SharedPtr-test] testStructPtrCopyOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			tc::SharedPtr<sFooStruct> foo(new sFooStruct);
+			tc::SharedPtr<sFooStruct> bar = foo;
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+
+void testPrimArrayPtrConstructor()
+{
+	std::cout << "[SharedPtr-test] testPrimArrayPtrConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(new int[100]);
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testPrimArrayPtrAssignmentOperator()
+{
+	std::cout << "[SharedPtr-test] testPrimArrayPtrAssignmentOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo = new int[100];
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testPrimArrayPtrCopyConstructor()
+{
+	std::cout << "[SharedPtr-test] testPrimArrayPtrCopyConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(new int[100]);
+			tc::SharedPtr<int> bar(foo);
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testPrimArrayPtrCopyOperator()
+{
+	std::cout << "[SharedPtr-test] testPrimArrayPtrCopyOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(new int[100]);
+			tc::SharedPtr<int> bar = foo;
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testArrayStructPtrConstructor()
+{
+	std::cout << "[SharedPtr-test] testArrayStructPtrConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			tc::SharedPtr<sFooStruct> foo(new sFooStruct[100]);
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testStructArrayPtrAssignmentOperator()
+{
+	std::cout << "[SharedPtr-test] testStructArrayPtrAssignmentOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			tc::SharedPtr<sFooStruct> foo = new sFooStruct[100];
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testStructArrayPtrCopyConstructor()
+{
+	std::cout << "[SharedPtr-test] testStructArrayPtrCopyConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			tc::SharedPtr<sFooStruct> foo(new sFooStruct[100]);
+			tc::SharedPtr<sFooStruct> bar(foo);
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testStructArrayPtrCopyOperator()
+{
+	std::cout << "[SharedPtr-test] testStructArrayPtrCopyOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			tc::SharedPtr<sFooStruct> foo(new sFooStruct[100]);
+			tc::SharedPtr<sFooStruct> bar = foo;
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testNullPtrConstructor()
+{
+	std::cout << "[SharedPtr-test] testNullPtrConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(nullptr);
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testNullPtrAssignmentOperator()
+{
+	std::cout << "[SharedPtr-test] testNullPtrAssignmentOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo = nullptr;
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testNullPtrCopyConstructor()
+{
+	std::cout << "[SharedPtr-test] testNullPtrCopyConstructor : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(nullptr);
+			tc::SharedPtr<int> bar(foo);
+		}
+
+		std::cout << "PASS" << std::endl;
+
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testNullPtrCopyOperator()
+{
+	std::cout << "[SharedPtr-test] testNullPtrCopyOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(nullptr);
+			tc::SharedPtr<int> bar = foo;
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testRepeatedAssignment()
+{
+	std::cout << "[SharedPtr-test] testRepeatedAssignment : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(new int);
+			foo = new int[100];
+			foo = new int[333];
+			foo = new int;
+			foo = new int;
+			foo = new int[1];
+			for (size_t i = 0; i < 1000; i++)
+			{
+				foo = new int[3];
+			}
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testReleasePtr()
+{
+	std::cout << "[SharedPtr-test] testReleasePtr : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(new int);
+			foo.release();
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testReleaseNullPtr()
+{
+	std::cout << "[SharedPtr-test] testReleaseNullPtr : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(nullptr);
+			foo.release();
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testDereferenceOperator()
+{
+	std::cout << "[SharedPtr-test] testDereferenceOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<int> foo(new int);
+			*foo = 13;
+
+			if (*foo != 13)
+			{
+				throw tc::Exception("SharedPtr::operator*() did not act as expected");
+			}
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testMemberAccessOperator()
+{
+	std::cout << "[SharedPtr-test] testMemberAccessOperator : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			tc::SharedPtr<sFooStruct> foo(new sFooStruct);
+			foo->b = 13;
+
+			if (foo->b != 13)
+			{
+				throw tc::Exception("SharedPtr::operator->() did not act as expected");
+			}
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testGetMethod()
+{
+	std::cout << "[SharedPtr-test] testGetMethod : ";
+	try
+	{
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			struct sFooStruct
+			{
+				int a;
+				int b;
+				uint32_t c;
+			};
+
+			sFooStruct* foo = new sFooStruct;
+
+			tc::SharedPtr<sFooStruct> bar = foo;
+
+			if (bar.get() != foo)
+			{
+				throw tc::Exception("SharedPtr::get() did not return expected ptr");
+			}
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testIsNullMethod()
+{
+	std::cout << "[SharedPtr-test] testIsNullMethod : ";
+	try
+	{
+		tc::SharedPtr<int> foo = nullptr;
+
+		if (foo.isNull() == false)
+		{
+			throw tc::Exception("isNull() returned false when data was not null");
+		}
+
+		foo = new int;
+
+		if (foo.isNull() == true)
+		{
+			throw tc::Exception("isNull() returned true when data was null");
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
+}
+
+void testChildDestructorCalledOnPtrRelease()
+{
+	std::cout << "[SharedPtr-test] testChildDestructorCalledOnPtrRelease : ";
+	class DummyClass
+	{
+	public:
+		DummyClass(size_t& incr_on_delete) :
+			mIncrOnDelete(incr_on_delete)
+		{
+		}
+
+		~DummyClass()
+		{
+			mIncrOnDelete += 1;
+		}
+	private:
+		size_t& mIncrOnDelete;
+	};
+
+	try
+	{
+		size_t destructor_count = 0;
+
+		tc::SharedPtr<DummyClass> foo = new DummyClass(destructor_count);
+
+		foo.release();
+
+		if (destructor_count != 1)
+		{
+			throw tc::Exception("DummyClass::~DummyClass() was not called on delete");
+		}
+
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
+	}
 }
 
 void testChildDestructorCalledOnSharedPtrDestructor()
 {
-	uint32_t var = kStartValue;
-	
-	outOfScope1(var);
-
-	if (var == kExpectedValue)
+	std::cout << "[SharedPtr-test] testChildDestructorCalledOnSharedPtrDestructor : ";
+	class DummyClass
 	{
-		std::cout << "[SharedPtr-test] testChildDestructorCalledOnSharedPtrDestructor() : PASS" << std::endl;
-	}
-	else
+	public:
+		DummyClass(size_t& incr_on_delete) :
+			mIncrOnDelete(incr_on_delete)
+		{
+		}
+
+		~DummyClass()
+		{
+			mIncrOnDelete += 1;
+		}
+	private:
+		size_t& mIncrOnDelete;
+	};
+
+	try
 	{
-		std::cout << "[SharedPtr-test] testChildDestructorCalledOnSharedPtrDestructor() : FAIL" << std::endl;
+		size_t destructor_count = 0;
+
+		// if statement so that foo is out of scope so it can be created and destroyed implicitly
+		if (true)
+		{
+			tc::SharedPtr<DummyClass> foo = new DummyClass(destructor_count);
+		}
+
+		if (destructor_count != 1)
+		{
+			throw tc::Exception("DummyClass::~DummyClass() was not called on delete");
+		}
+
+		std::cout << "PASS" << std::endl;
 	}
-}
-
-void outOfScope2(uint32_t& var)
-{
-	tc::SharedPtr<TestClass> obj = new TestClass(var);
-
-	std::vector<tc::SharedPtr<TestClass>> obj_duplicates;
-	for (size_t i = 0; i < 1000; i++)
+	catch (const std::exception& e)
 	{
-		obj_duplicates.push_back(obj);
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
 	}
-
-	obj_duplicates[500].operator*()->setOnDeathVal(kExpectedValue+5);
 }
 
 void testLargeReferenceCount()
 {
-	uint32_t var = kStartValue;
-	
-	outOfScope2(var);
-
-	if (var == kExpectedValue+5)
+	std::cout << "[SharedPtr-test] testLargeReferenceCount : ";
+	class DummyClass
 	{
-		std::cout << "[SharedPtr-test] testLargeReferenceCount() : PASS" << std::endl;
+	public:
+		DummyClass(uint32_t& var, uint32_t on_death_val):
+			mVar(var),
+			mOnDeathVal(on_death_val)
+		{}
+
+		~DummyClass()
+		{
+			mVar = mOnDeathVal;
+		}
+
+		void setOnDeathVal(uint32_t val)
+		{
+			mOnDeathVal = val;
+		}
+	private:
+		uint32_t& mVar;	
+		uint32_t mOnDeathVal;
+	};
+
+	try
+	{
+		static const uint32_t kStartValue = 0xCAFEBABE;
+		static const uint32_t kExpectedValue = 0xDEADBEEF;
+
+		uint32_t var = kStartValue;
+		
+		if (true)
+		{
+			tc::SharedPtr<DummyClass> obj = new DummyClass(var, kExpectedValue);
+
+			std::vector<tc::SharedPtr<DummyClass>> obj_duplicates;
+			for (size_t i = 0; i < 1000; i++)
+			{
+				obj_duplicates.push_back(obj);
+			}
+
+			obj_duplicates[510].release();
+			obj_duplicates[500]->setOnDeathVal(kExpectedValue+5);
+			obj_duplicates[3].release();
+		}
+
+		if (var != kExpectedValue+5)
+		{
+			throw tc::Exception("DummyClass::~DummyClass() was not called on delete");
+		}
+		std::cout << "PASS" << std::endl;
 	}
-	else
+	catch (const std::exception& e)
 	{
-		std::cout << "[SharedPtr-test] testLargeReferenceCount() : FAIL" << std::endl;
-	}
-}
-
-void outOfScope3(uint32_t& var)
-{
-	tc::SharedPtr<TestClass> obj;
-
-	obj.operator*();
-
-	obj = nullptr;
-
-	obj.operator*();
-}
-
-void testAssignNullPtr()
-{
-	uint32_t var = kStartValue;
-	
-	outOfScope3(var);
-
-	if (var == kStartValue)
-	{
-		std::cout << "[SharedPtr-test] testAssignNullPtr() : PASS" << std::endl;
-	}
-	else
-	{
-		std::cout << "[SharedPtr-test] testAssignNullPtr() : FAIL" << std::endl;
+		std::cout << "FAIL (" << e.what() << ")" << std::endl;
 	}
 }
 
 int main(int argc, char** argv)
 {
+	testDefaultConstructor();
+	testPrimPtrConstructor();
+	testPrimPtrAssignmentOperator();
+	testPrimPtrCopyConstructor();
+	testPrimPtrCopyOperator();
+	testStructPtrConstructor();
+	testStructPtrAssignmentOperator();
+	testStructPtrCopyConstructor();
+	testStructPtrCopyOperator();
+	testPrimArrayPtrConstructor();
+	testPrimArrayPtrAssignmentOperator();
+	testPrimArrayPtrCopyConstructor();
+	testPrimArrayPtrCopyOperator();
+	testArrayStructPtrConstructor();
+	testStructArrayPtrAssignmentOperator();
+	testStructArrayPtrCopyConstructor();
+	testStructArrayPtrCopyOperator();
+	testNullPtrConstructor();
+	testNullPtrAssignmentOperator();
+	testNullPtrCopyConstructor();
+	testNullPtrCopyOperator();
+	testRepeatedAssignment();
+	testReleasePtr();
+	testReleaseNullPtr();
+	testDereferenceOperator();
+	testMemberAccessOperator();
+	testIsNullMethod();
+	testChildDestructorCalledOnPtrRelease();
 	testChildDestructorCalledOnSharedPtrDestructor();
 	testLargeReferenceCount();
-	testAssignNullPtr();
 }


### PR DESCRIPTION
Test program for SharedPtr updated with more comprehensive tests.
All of the code that uses SharedPtr has been update.

Added in v0.2:
* `T& operator*()` Deference managed pointer
* `T* get()` Direct access to managed pointer
* `void isNull()` Check if managed pointer is null
* `void release()` Manually free managed pointer (only frees pointer if this is the last instance)

Changed from v0.1:
* Logic for handling nullptr is improved, fixed copy assignment bug
* `T* operator*()` replaced with `T* operator->()`