### PR TITLE
Copy/Move operators/constructors for Generic types are now equivalent…

### DIFF
--- a/include/tc/fs/GenericFileObject.h
+++ b/include/tc/fs/GenericFileObject.h
@@ -36,37 +36,6 @@ public:
 		 * @param[in] other GenericFileObject object to move
 		 */
 	GenericFileObject(tc::fs::IFileObject&& other);
-
-		/**
-		 * @brief Copy Constructor
-		 * @param[in] other GenericFileObject object to copy
-		 */
-	GenericFileObject(const tc::fs::GenericFileObject& other);
-
-		/**
-		 * @brief Move Constructor
-		 * @param[in] other GenericFileObject object to move
-		 */
-	GenericFileObject(tc::fs::GenericFileObject&& other);
-
-		/// Destructor
-	~GenericFileObject();
-
-		/**
-		 * @brief Copy Assignment Operator
-		 * @param[in] other GenericFileObject object to copy
-		 * 
-		 * @return this object
-		 */
-	GenericFileObject& operator=(const tc::fs::GenericFileObject& other);
-
-		/**
-		 * @brief Move Assignment Operator
-		 * @param[in] other GenericFileObject object to move
-		 * 
-		 * @return this object
-		 */
-	GenericFileObject& operator=(tc::fs::GenericFileObject&& other);
 	
 	virtual tc::fs::IFileObject* copyInstance() const;
 	virtual tc::fs::IFileObject* moveInstance();

--- a/include/tc/fs/GenericFileSystem.h
+++ b/include/tc/fs/GenericFileSystem.h
@@ -37,37 +37,6 @@ public:
 		 */
 	GenericFileSystem(tc::fs::IFileSystem&& other);
 
-		/**
-		 * @brief Copy Constructor
-		 * @param[in] other GenericFileSystem object to copy
-		 */
-	GenericFileSystem(const tc::fs::GenericFileSystem& other);
-
-		/**
-		 * @brief Move Constructor
-		 * @param[in] other GenericFileSystem object to move
-		 */
-	GenericFileSystem(tc::fs::GenericFileSystem&& other);
-
-		/// Destructor
-	~GenericFileSystem();
-
-		/**
-		 * @brief Copy Assignment Operator
-		 * @param[in] other GenericFileSystem object to copy
-		 * 
-		 * @return this object
-		 */
-	GenericFileSystem& operator=(const tc::fs::GenericFileSystem& other);
-
-		/**
-		 * @brief Move Assignment Operator
-		 * @param[in] other GenericFileSystem object to move
-		 * 
-		 * @return this object
-		 */
-	GenericFileSystem& operator=(tc::fs::GenericFileSystem&& other);
-
 	virtual tc::fs::IFileSystem* copyInstance() const;
 	virtual tc::fs::IFileSystem* moveInstance();
 

--- a/src/fs/GenericFileObject.cpp
+++ b/src/fs/GenericFileObject.cpp
@@ -9,18 +9,6 @@ tc::fs::GenericFileObject::GenericFileObject() :
 {
 }
 
-tc::fs::GenericFileObject::GenericFileObject(const tc::fs::GenericFileObject& other) :
-	GenericFileObject()
-{
-	*this = other;
-}
-
-tc::fs::GenericFileObject::GenericFileObject(tc::fs::GenericFileObject&& other) :
-	GenericFileObject()
-{
-	*this = std::move(other);
-}
-
 tc::fs::GenericFileObject::GenericFileObject(const tc::fs::IFileObject& other) :
 	mPtr(other.copyInstance())
 {
@@ -39,29 +27,6 @@ tc::fs::GenericFileObject::GenericFileObject(tc::fs::IFileObject&& other) :
 	{
 		mPtr.release();
 	}
-}
-
-tc::fs::GenericFileObject::~GenericFileObject()
-{
-	mPtr.release();
-}
-
-tc::fs::GenericFileObject& tc::fs::GenericFileObject::operator=(const tc::fs::GenericFileObject& other)
-{
-	if (this != &other)
-	{
-		mPtr = other.mPtr;
-	}
-	return *this;
-}
-
-tc::fs::GenericFileObject& tc::fs::GenericFileObject::operator=(tc::fs::GenericFileObject&& other)
-{
-	if (this != &other)
-	{
-		mPtr = std::move(other.mPtr);
-	}
-	return *this;
 }
 
 tc::fs::IFileObject* tc::fs::GenericFileObject::copyInstance() const

--- a/src/fs/GenericFileSystem.cpp
+++ b/src/fs/GenericFileSystem.cpp
@@ -9,18 +9,6 @@ tc::fs::GenericFileSystem::GenericFileSystem():
 {
 }
 
-tc::fs::GenericFileSystem::GenericFileSystem(const tc::fs::GenericFileSystem& other) :
-	GenericFileSystem()
-{
-	*this = other;
-}
-
-tc::fs::GenericFileSystem::GenericFileSystem(tc::fs::GenericFileSystem&& other) :
-	GenericFileSystem()
-{
-	*this = std::move(other);
-}
-
 tc::fs::GenericFileSystem::GenericFileSystem(const tc::fs::IFileSystem& other) :
 	mPtr(other.copyInstance())
 {
@@ -39,29 +27,6 @@ tc::fs::GenericFileSystem::GenericFileSystem(tc::fs::IFileSystem&& other) :
 	{
 		mPtr.release();
 	}
-}
-
-tc::fs::GenericFileSystem::~GenericFileSystem()
-{
-	mPtr.release();
-}
-
-tc::fs::GenericFileSystem& tc::fs::GenericFileSystem::operator=(const tc::fs::GenericFileSystem& other)
-{
-	if (this != &other)
-	{
-		mPtr = other.mPtr;
-	}
-	return *this;
-}
-
-tc::fs::GenericFileSystem& tc::fs::GenericFileSystem::operator=(tc::fs::GenericFileSystem&& other)
-{
-	if (this != &other)
-	{
-		mPtr = std::move(other.mPtr);
-	}
-	return *this;
 }
 
 tc::fs::IFileSystem* tc::fs::GenericFileSystem::copyInstance() const


### PR DESCRIPTION
… to implicit versions, so remove.