### PR TITLE
Feature: templated 16, 32, & 64bit endian-types.

### DIFF
--- a/include/tc/bitwise_types.h
+++ b/include/tc/bitwise_types.h
@@ -1,0 +1,54 @@
+	/**
+	 * @file bitwise_types.h
+	 * @brief Declaration of macros and classes to handle literal bit-fields and bit-masks/bit-shifting.
+	 * @author Jack (jakcron)
+	 * @version 0.1
+	 * @date 2020/12/05
+	 **/
+#pragma once
+#include <array>
+#include <cinttypes>
+
+namespace tc {
+
+template <size_t T, bool byte_order_le = true, bool bit_order_le = true>
+struct bitfield
+{
+public:
+#define __BITFIELD_BYTE_INDEX_MATH(x) (byte_order_le? (x / 8) : (T - 1 - (x / 8)))
+#define __BITFIELD_BIT_INDEX_MATH(x) (bit_order_le? (1 << (x % 8)) : (1 << (7 - (x % 8))))
+
+	size_t bit_size() const { return T * 8; }
+
+	void set(size_t bit)
+	{
+		bit %= (T*8);
+		mArray[__BITFIELD_BYTE_INDEX_MATH(bit)] |= __BITFIELD_BIT_INDEX_MATH(bit);
+	}
+
+	void reset(size_t bit)
+	{
+		bit %= (T*8);
+		mArray[__BITFIELD_BYTE_INDEX_MATH(bit)] &= ~(uint8_t(__BITFIELD_BIT_INDEX_MATH(bit)));
+	}
+
+	void flip(size_t bit)
+	{
+		bit %= (T*8);
+		test(bit) ? reset(bit) : set(bit);
+	}
+
+	bool test(size_t bit) const
+	{
+		bit %= (T*8);
+		return (mArray[__BITFIELD_BYTE_INDEX_MATH(bit)] & (__BITFIELD_BIT_INDEX_MATH(bit))) != 0;
+	}
+
+#undef __BITFIELD_BYTE_INDEX_MATH
+#undef __BITFIELD_BIT_INDEX_MATH
+
+private:
+	std::array<uint8_t, T> mArray;
+};
+
+}

--- a/include/tc/endian.h
+++ b/include/tc/endian.h
@@ -7,6 +7,7 @@
 	 **/
 #pragma once
 #include <cinttypes>
+#include <type_traits>
 
 static inline uint16_t __local_bswap16(uint16_t x) {
 	return ((x << 8) & 0xff00) | ((x >> 8) & 0x00ff);
@@ -125,3 +126,115 @@ public:
 private:
 	uint64_t mVar;
 };
+
+namespace tc {
+
+	/**
+	 * @struct le16
+	 * @brief Wrapper that allows accessing a little-endian uint16_t regardless of processor endianness 
+	 **/
+template <typename T>
+struct le16 {
+public:
+	static_assert(sizeof(T) == sizeof(uint16_t), "le16 requires T to be 16 bit.");
+	static_assert(std::is_pod<T>::value, "le16 requires T to be a POD.");
+
+		/// Unwrap value
+	inline T unwrap() const { auto tmp = __le_uint16(mVar); return *((T*)(&tmp)); }
+		/// Wrap value
+	inline void wrap(const T& var) { mVar = __le_uint16(*((uint16_t*)(&var))); }
+private:
+	uint16_t mVar;
+};
+
+	/**
+	 * @struct be16
+	 * @brief Wrapper that allows accessing a big-endian uint16_t regardless of processor endianness 
+	 **/
+template <typename T>
+struct be16 {
+public:
+	static_assert(sizeof(T) == sizeof(uint16_t), "be16 requires T to be 16 bit.");
+	static_assert(std::is_pod<T>::value, "be16 requires T to be a POD.");
+
+		/// Unwrap value
+	inline T unwrap() const { auto tmp = __be_uint16(mVar); return *((T*)(&tmp)); }
+		/// Wrap value
+	inline void wrap(const T& var) { mVar = __be_uint16(*((uint16_t*)(&var))); }
+private:
+	uint16_t mVar;
+};
+
+	/**
+	 * @struct le32
+	 * @brief Wrapper that allows accessing a little-endian uint32_t regardless of processor endianness 
+	 **/
+template <typename T>
+struct le32 {
+public:
+	static_assert(sizeof(T) == sizeof(uint32_t), "le32 requires T to be 32 bit.");
+	static_assert(std::is_pod<T>::value, "le32 requires T to be a POD.");
+
+		/// Unwrap value
+	inline T unwrap() const { auto tmp = __le_uint32(mVar); return *((T*)(&tmp)); }
+		/// Wrap value
+	inline void wrap(const T& var) { mVar = __le_uint32(*((uint32_t*)(&var))); }
+private:
+	uint32_t mVar;
+};
+
+	/**
+	 * @struct be32
+	 * @brief Wrapper that allows accessing a big-endian uint32_t regardless of processor endianness 
+	 **/
+template <typename T>
+struct be32 {
+public:
+	static_assert(sizeof(T) == sizeof(uint32_t), "be32 requires T to be 32 bit.");
+	static_assert(std::is_pod<T>::value, "be32 requires T to be a POD.");
+
+		/// Unwrap value
+	inline T unwrap() const { auto tmp = __be_uint32(mVar); return *((T*)(&tmp)); }
+		/// Wrap value
+	inline void wrap(const T& var) { mVar = __be_uint32(*((uint32_t*)(&var))); }
+private:
+	uint32_t mVar;
+};
+
+	/**
+	 * @struct le64
+	 * @brief Wrapper that allows accessing a little-endian uint64_t regardless of processor endianness 
+	 **/
+template <typename T>
+struct le64 {
+public:
+	static_assert(sizeof(T) == sizeof(uint64_t), "le64 requires T to be 64 bit.");
+	static_assert(std::is_pod<T>::value, "le64 requires T to be a POD.");
+
+		/// Unwrap value
+	inline T unwrap() const { auto tmp = __le_uint64(mVar); return *((T*)(&tmp)); }
+		/// Wrap value
+	inline void wrap(const T& var) { mVar = __le_uint64(*((uint64_t*)(&var))); }
+private:
+	uint64_t mVar;
+};
+
+	/**
+	 * @struct be64
+	 * @brief Wrapper that allows accessing a big-endian uint64_t regardless of processor endianness 
+	 **/
+template <typename T>
+struct be64 {
+public:
+	static_assert(sizeof(T) == sizeof(uint64_t), "be64 requires T to be 64 bit.");
+	static_assert(std::is_pod<T>::value, "be64 requires T to be a POD.");
+
+		/// Unwrap value
+	inline T unwrap() const { auto tmp = __be_uint64(mVar); return *((T*)(&tmp)); }
+		/// Wrap value
+	inline void wrap(const T& var) { mVar = __be_uint64(*((uint64_t*)(&var))); }
+private:
+	uint64_t mVar;
+};
+
+} // namespace tc

--- a/include/tc/endian_types.h
+++ b/include/tc/endian_types.h
@@ -1,9 +1,9 @@
 	/**
-	 * @file endian.h
-	 * @brief Declaration of macros and classes to unwrap primatives in an endian agnostic way
+	 * @file endian_types.h
+	 * @brief Declaration of macros and classes to unwrap primatives in an endian agnostic way.
 	 * @author Jack (jakcron)
 	 * @version 0.1
-	 * @date 2019/01/15
+	 * @date 2020/12/05
 	 **/
 #pragma once
 #include <cinttypes>
@@ -131,7 +131,7 @@ namespace tc {
 
 	/**
 	 * @struct le16
-	 * @brief Wrapper that allows accessing a little-endian uint16_t regardless of processor endianness 
+	 * @brief Wrapper that allows accessing a little-endian 16-bit POD regardless of processor endianness 
 	 **/
 template <typename T>
 struct le16 {
@@ -149,7 +149,7 @@ private:
 
 	/**
 	 * @struct be16
-	 * @brief Wrapper that allows accessing a big-endian uint16_t regardless of processor endianness 
+	 * @brief Wrapper that allows accessing a big-endian 16-bit POD regardless of processor endianness 
 	 **/
 template <typename T>
 struct be16 {
@@ -167,7 +167,7 @@ private:
 
 	/**
 	 * @struct le32
-	 * @brief Wrapper that allows accessing a little-endian uint32_t regardless of processor endianness 
+	 * @brief Wrapper that allows accessing a little-endian 32-bit POD regardless of processor endianness 
 	 **/
 template <typename T>
 struct le32 {
@@ -185,7 +185,7 @@ private:
 
 	/**
 	 * @struct be32
-	 * @brief Wrapper that allows accessing a big-endian uint32_t regardless of processor endianness 
+	 * @brief Wrapper that allows accessing a big-endian 32-bit POD regardless of processor endianness 
 	 **/
 template <typename T>
 struct be32 {
@@ -203,7 +203,7 @@ private:
 
 	/**
 	 * @struct le64
-	 * @brief Wrapper that allows accessing a little-endian uint64_t regardless of processor endianness 
+	 * @brief Wrapper that allows accessing a little-endian 64-bit POD regardless of processor endianness 
 	 **/
 template <typename T>
 struct le64 {
@@ -221,7 +221,7 @@ private:
 
 	/**
 	 * @struct be64
-	 * @brief Wrapper that allows accessing a big-endian uint64_t regardless of processor endianness 
+	 * @brief Wrapper that allows accessing a big-endian 64-bit POD regardless of processor endianness 
 	 **/
 template <typename T>
 struct be64 {

--- a/include/tc/types.h
+++ b/include/tc/types.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <array>
 #include <vector>
+#include <map>
 #include <cstdint>
 #include <cstring>
 #include <memory>

--- a/include/tc/types.h
+++ b/include/tc/types.h
@@ -14,7 +14,8 @@
 #include <memory>
 #include <algorithm>
 #include <type_traits>
-#include <tc/endian.h>
+#include <tc/endian_types.h>
+#include <tc/bitwise_types.h>
 
 #ifdef _WIN32
 #define NOMINMAX

--- a/test/endian_TestClass.cpp
+++ b/test/endian_TestClass.cpp
@@ -21,6 +21,12 @@ void endian_TestClass::runAllTests()
 	testLeUint64Class();
 	testLeUint32Class();
 	testLeUint16Class();
+	testBe64TemplateClass();
+	testBe32TemplateClass();
+	testBe16TemplateClass();
+	testLe64TemplateClass();
+	testLe32TemplateClass();
+	testLe16TemplateClass();
 	std::cout << "[:: endian] END" << std::endl;
 }
 
@@ -419,6 +425,216 @@ void endian_TestClass::testLeUint16Class()
 		if (memcmp(x_raw, x_raw_expected, sizeof(uint16_t)) != 0 || x_raw_ptr->unwrap() != x_expected)
 		{
 			throw tc::Exception("le_uint16_t::wrap() did not wrap test value correectly");
+		}
+		
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const tc::Exception& e)
+	{
+		std::cout << "FAIL (" << e.error() << ")" << std::endl;
+	}
+}
+
+void endian_TestClass::testBe64TemplateClass()
+{
+	std::cout << "[tc::be64<uint64_t>] testBe64TemplateClass : " << std::flush;
+	try 
+	{
+		uint8_t x_raw[sizeof(uint64_t)] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+		uint8_t x_raw_expected[sizeof(uint64_t)] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+		tc::be64<uint64_t>* x_raw_ptr = (tc::be64<uint64_t>*)&x_raw;
+		uint64_t x_expected = 0x0123456789abcdef;
+
+		if (x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::be64<uint64_t>::unwrap() did not return expected result");
+		}
+
+		x_raw_ptr->wrap(0);
+		if (x_raw_ptr->unwrap() != 0)
+		{
+			throw tc::Exception("tc::be64<uint64_t>::wrap() did not wrap value 0x0 correctly");
+		}
+
+		x_raw_ptr->wrap(x_expected);
+		if (memcmp(x_raw, x_raw_expected, sizeof(uint64_t)) != 0 || x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::be64<uint64_t>::wrap() did not wrap test value correectly");
+		}
+		
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const tc::Exception& e)
+	{
+		std::cout << "FAIL (" << e.error() << ")" << std::endl;
+	}
+}
+
+void endian_TestClass::testBe32TemplateClass()
+{
+	std::cout << "[tc::be32<uint32_t>] testBe32TemplateClass : " << std::flush;
+	try 
+	{
+		uint8_t x_raw[sizeof(uint32_t)] = { 0x01, 0x23, 0x45, 0x67 };
+		uint8_t x_raw_expected[sizeof(uint32_t)] = { 0x01, 0x23, 0x45, 0x67 };
+		tc::be32<uint32_t>* x_raw_ptr = (tc::be32<uint32_t>*)&x_raw;
+		uint32_t x_expected = 0x01234567;
+
+		if (x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::be32<uint32_t>::unwrap() did not return expected result");
+		}
+
+		x_raw_ptr->wrap(0);
+		if (x_raw_ptr->unwrap() != 0)
+		{
+			throw tc::Exception("tc::be32<uint32_t>::wrap() did not wrap value 0x0 correctly");
+		}
+
+		x_raw_ptr->wrap(x_expected);
+		if (memcmp(x_raw, x_raw_expected, sizeof(uint32_t)) != 0 || x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::be32<uint32_t>::wrap() did not wrap test value correectly");
+		}
+		
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const tc::Exception& e)
+	{
+		std::cout << "FAIL (" << e.error() << ")" << std::endl;
+	}
+}
+
+void endian_TestClass::testBe16TemplateClass()
+{
+	std::cout << "[tc::be16<uint16_t>] testBe16TemplateClass : " << std::flush;
+	try 
+	{
+		uint8_t x_raw[sizeof(uint16_t)] = { 0x01, 0x23 };
+		uint8_t x_raw_expected[sizeof(uint16_t)] = { 0x01, 0x23 };
+		tc::be16<uint16_t>* x_raw_ptr = (tc::be16<uint16_t>*)&x_raw;
+		uint16_t x_expected = 0x0123;
+
+		if (x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::be16<uint16_t>::unwrap() did not return expected result");
+		}
+
+		x_raw_ptr->wrap(0);
+		if (x_raw_ptr->unwrap() != 0)
+		{
+			throw tc::Exception("tc::be16<uint16_t>::wrap() did not wrap value 0x0 correctly");
+		}
+
+		x_raw_ptr->wrap(x_expected);
+		if (memcmp(x_raw, x_raw_expected, sizeof(uint16_t)) != 0 || x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::be16<uint16_t>::wrap() did not wrap test value correectly");
+		}
+		
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const tc::Exception& e)
+	{
+		std::cout << "FAIL (" << e.error() << ")" << std::endl;
+	}
+}
+
+void endian_TestClass::testLe64TemplateClass()
+{
+	std::cout << "[tc::le64<uint64_t>] testLe64TemplateClass : " << std::flush;
+	try 
+	{
+		uint8_t x_raw[sizeof(uint64_t)] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+		uint8_t x_raw_expected[sizeof(uint64_t)] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+		tc::le64<uint64_t>* x_raw_ptr = (tc::le64<uint64_t>*)&x_raw;
+		uint64_t x_expected = 0xefcdab8967452301;
+
+		if (x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::le64<uint64_t>::unwrap() did not return expected result");
+		}
+
+		x_raw_ptr->wrap(0);
+		if (x_raw_ptr->unwrap() != 0)
+		{
+			throw tc::Exception("tc::le64<uint64_t>::wrap() did not wrap value 0x0 correctly");
+		}
+
+		x_raw_ptr->wrap(x_expected);
+		if (memcmp(x_raw, x_raw_expected, sizeof(uint64_t)) != 0 || x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::le64<uint64_t>::wrap() did not wrap test value correectly");
+		}
+		
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const tc::Exception& e)
+	{
+		std::cout << "FAIL (" << e.error() << ")" << std::endl;
+	}
+}
+
+void endian_TestClass::testLe32TemplateClass()
+{
+	std::cout << "[::tc::le32<uint32_t>] testLe32TemplateClass : " << std::flush;
+	try 
+	{
+		uint8_t x_raw[sizeof(uint32_t)] = { 0x01, 0x23, 0x45, 0x67 };
+		uint8_t x_raw_expected[sizeof(uint32_t)] = { 0x01, 0x23, 0x45, 0x67 };
+		tc::le32<uint32_t>* x_raw_ptr = (tc::le32<uint32_t>*)&x_raw;
+		uint32_t x_expected = 0x67452301;
+
+		if (x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::le32<uint32_t>::unwrap() did not return expected result");
+		}
+
+		x_raw_ptr->wrap(0);
+		if (x_raw_ptr->unwrap() != 0)
+		{
+			throw tc::Exception("tc::le32<uint32_t>::wrap() did not wrap value 0x0 correctly");
+		}
+
+		x_raw_ptr->wrap(x_expected);
+		if (memcmp(x_raw, x_raw_expected, sizeof(uint32_t)) != 0 || x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::le32<uint32_t>::wrap() did not wrap test value correectly");
+		}
+		
+		std::cout << "PASS" << std::endl;
+	}
+	catch (const tc::Exception& e)
+	{
+		std::cout << "FAIL (" << e.error() << ")" << std::endl;
+	}
+}
+
+void endian_TestClass::testLe16TemplateClass()
+{
+	std::cout << "[tc::le16<uint16_t>] testLe16TemplateClass : " << std::flush;
+	try 
+	{
+		uint8_t x_raw[sizeof(uint16_t)] = { 0x01, 0x23 };
+		uint8_t x_raw_expected[sizeof(uint16_t)] = { 0x01, 0x23 };
+		tc::le16<uint16_t>* x_raw_ptr = (tc::le16<uint16_t>*)&x_raw;
+		uint16_t x_expected = 0x2301;
+
+		if (x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::le16<uint16_t>::unwrap() did not return expected result");
+		}
+
+		x_raw_ptr->wrap(0);
+		if (x_raw_ptr->unwrap() != 0)
+		{
+			throw tc::Exception("tc::le16<uint16_t>::wrap() did not wrap value 0x0 correctly");
+		}
+
+		x_raw_ptr->wrap(x_expected);
+		if (memcmp(x_raw, x_raw_expected, sizeof(uint16_t)) != 0 || x_raw_ptr->unwrap() != x_expected)
+		{
+			throw tc::Exception("tc::le16<uint16_t>::wrap() did not wrap test value correectly");
 		}
 		
 		std::cout << "PASS" << std::endl;

--- a/test/endian_TestClass.h
+++ b/test/endian_TestClass.h
@@ -21,4 +21,10 @@ private:
 	void testLeUint64Class();
 	void testLeUint32Class();
 	void testLeUint16Class();
+	void testBe64TemplateClass();
+	void testBe32TemplateClass();
+	void testBe16TemplateClass();
+	void testLe64TemplateClass();
+	void testLe32TemplateClass();
+	void testLe16TemplateClass();
 };


### PR DESCRIPTION
# Overview
This adds template classes for (de)serialising 16,32,64 bit POD data types.
* `tc::be64<>` - Big endian 64bit POD.
* `tc::be32<>` - Big endian 32bit POD.
* `tc::be16<>` - Big endian 16bit POD.
* `tc::le64<>` - Little endian 64bit POD.
* `tc::le32<>` - Little endian 32bit POD.
* `tc::le16<>` - Little endian 16bit POD.

These classes were added as a part of the _dog fooding_ libtoolchain integration testing.

# Tests
Test were added to `endian_TestClass`, and currently pass.