### PR TITLE
Revise wording around API documentation in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For GNU/unix systems `make` can be used. For native Windows, Visual Studio proje
 See more [here](./BUILDING.md).
 
 # Documentation
-The documentation is available at docs/index.html. Or alternatively at https://jakcron.github.io/libtoolchain.
+The documentation can be generated using Doxygen, and created at docs/index.html. Alternatively documentation for the current stable version is available at https://jakcron.github.io/libtoolchain-docs.
 
 # License 
 This source code is made available under the [MIT license](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For GNU/unix systems `make` can be used. For native Windows, Visual Studio proje
 See more [here](./BUILDING.md).
 
 # Documentation
-The documentation can be generated using Doxygen, and created at docs/index.html. Alternatively documentation for the current stable version is available at https://jakcron.github.io/libtoolchain-docs.
+API Documentation is generated using Doxygen, and located at docs/index.html. Alternatively documentation for the current stable version is available at https://jakcron.github.io/libtoolchain-docs.
 
 # License 
 This source code is made available under the [MIT license](./LICENSE).


### PR DESCRIPTION
# About
I'm moving documentation to a separate repsitory to reduce the size when cloning. So the link in the README needed updating, so I've also taken this moment to revise the wording as well.